### PR TITLE
refactor : message service refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /backend/Inventory/__pycache__
 /backend/Inventory/itemClass.py
 /backend/Inventory/test.py
+/backend/RabbitMQ/compose.yml
 
 # Feel free to include your own ignore files below
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -80,46 +80,42 @@ services:
       - "5672:5672"
       - "15672:15672"
     healthcheck:
-      test: ["CMD", "rabbitmqctl", "status"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+      test: [ "CMD", "rabbitmqctl", "status" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    environment:
+      - RABBITMQ_DEFAULT_USER=admin
+      - RABBITMQ_DEFAULT_PASS=password
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
     networks:
       - charity_network
 
-  message:
-    container_name: message
-    build: ./message
-    image: matthew160619/is213-cloudpantry:message
-    ports:
-      # - "${MESSAGE_PORT}:8000"
-      - "${MESSAGE_PORT}:5100"
-    networks:
-      - charity_network      
-
-
-  messagenf:
-    container_name: messagenf
+  amqp-setup:
     build:
-      context: ./messagenf
+      context: ./rabbitmq
       dockerfile: Dockerfile
-    image: matthew160619/is213-cloudpantry:messagenf
-    ports:
-      # - "${MESSAGENF_PORT}:8000"
-      - "${MESSAGENF_PORT}:5101"
-    depends_on: # rabbitmq start b4 the notification listener
+    container_name: amqp-setup
+    depends_on:
+      # rabbitmq start b4 the notification listener
       charitymq:
         condition: service_healthy
+    environment:
+      - CHARITY_ENDPOINT=https://personal-d4txim0d.outsystemscloud.com/Charity/rest/CharityAPI
+      - RABBITMQ_HOST=charitymq
+      - RABBITMQ_USER=admin
+      - RABBITMQ_PASS=password
     networks:
       - charity_network
-    restart: on-failure 
+      - route
+    restart: on-failure
 
-# For route-optimiser microservice
+  # For route-optimiser microservice
 networks:
   route:
     driver: bridge
+  # For rabbitMQ microservice
   charity_network:
     driver: bridge
 

--- a/backend/rabbitMQ/Dockerfile
+++ b/backend/rabbitMQ/Dockerfile
@@ -1,0 +1,26 @@
+# Use a lightweight Python image
+FROM python:3.9-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files
+COPY amqp_setup.py .
+COPY startAMQP.py .
+COPY rabbitMQ_SetUpTest.py .
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Runs tests and ensure all success before launching inventory.py
+RUN echo '#!/bin/bash\n\
+    python rabbitMQ_SetUpTest.py\n\
+    if [ $? -ne 0 ]; then\n\
+    echo "rabbitMQ_SetUpTest.py failed"\n\
+    exit 1\n\
+    fi\n\
+    exec python startAMQP.py' > /app/start.sh && chmod +x /app/start.sh
+
+# Run the Flask application
+CMD ["/app/start.sh"]

--- a/backend/rabbitMQ/amqp_setup.py
+++ b/backend/rabbitMQ/amqp_setup.py
@@ -1,16 +1,6 @@
 #!/usr/bin/env python3
 import pika
-import os
-from dotenv import load_dotenv
 import requests
-
-load_dotenv()
-
-amqp_host = "charitymq"
-amqp_port = 5672
-exchange_name = "charity_exchange"
-exchange_type = "direct"
-CHARITY_ENDPOINT: str = os.getenv('CHARITY_ENDPOINT', "https://personal-d4txim0d.outsystemscloud.com/Charity/rest/CharityAPI/")
 
 def create_connection(hostname, port):
     connection = pika.BlockingConnection(
@@ -19,8 +9,9 @@ def create_connection(hostname, port):
             port=port,
             heartbeat=300,
             blocked_connection_timeout=300,
+            credentials=pika.PlainCredentials('admin', 'password')
+            )
         )
-    )
     return connection
 
 def create_exchange(connection,exchange_name, exchange_type):
@@ -32,10 +23,11 @@ def create_queue(channel, exchange_name, queue_name, routing_key):
     channel.queue_declare(queue=queue_name, durable=True)
     channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=routing_key)
 
-def close_connection(connection):
+def close_connection(amqp_host):
+    connection = pika.BlockingConnection(pika.ConnectionParameters(amqp_host))
     connection.close()
 
-def setup():
+def setup(amqp_host,amqp_port,exchange_name,exchange_type,CHARITY_ENDPOINT):
     # Create Connection
     try:
         connection = create_connection(amqp_host, amqp_port)

--- a/backend/rabbitMQ/amqp_setup.py
+++ b/backend/rabbitMQ/amqp_setup.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import pika
+import os
+from dotenv import load_dotenv
+import requests
+
+load_dotenv()
+
+amqp_host = "charitymq"
+amqp_port = 5672
+exchange_name = "charity_exchange"
+exchange_type = "direct"
+CHARITY_ENDPOINT: str = os.getenv('CHARITY_ENDPOINT', "https://personal-d4txim0d.outsystemscloud.com/Charity/rest/CharityAPI/")
+
+def create_connection(hostname, port):
+    connection = pika.BlockingConnection(
+        pika.ConnectionParameters(
+            host=hostname,
+            port=port,
+            heartbeat=300,
+            blocked_connection_timeout=300,
+        )
+    )
+    return connection
+
+def create_exchange(connection,exchange_name, exchange_type):
+    channel = connection.channel()
+    channel.exchange_declare(exchange=exchange_name, exchange_type=exchange_type, durable=True)
+    return channel
+
+def create_queue(channel, exchange_name, queue_name, routing_key):
+    channel.queue_declare(queue=queue_name, durable=True)
+    channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=routing_key)
+
+def close_connection(connection):
+    connection.close()
+
+def setup():
+    # Create Connection
+    try:
+        connection = create_connection(amqp_host, amqp_port)
+    except Exception as e:
+        print(f"[ERROR] Initiation of RabbitMQ Connection Fail: {e}")
+
+    # Create Exchange
+    try:
+        channel = create_exchange(connection,exchange_name,exchange_type)
+    except Exception as e:
+        print(f"[ERROR] Initiation of Charity Exchange Fail: {e}")
+
+    # Create and Bind Queue for Each Charity in Charity Database
+    try:
+        response = requests.get(f"{CHARITY_ENDPOINT}/GetAllCharityIDName")
+        response.raise_for_status()
+        for charity in response.json():
+            create_queue(
+                channel=channel,
+                exchange_name=exchange_name,
+                queue_name=charity["CharityName"],
+                routing_key=f"charity.{charity['ID']}",
+            )
+    except Exception as e:
+        print(f"[ERROR] Unable to reach Charity API: {e}")

--- a/backend/rabbitMQ/rabbitMQ_SetUpTest.py
+++ b/backend/rabbitMQ/rabbitMQ_SetUpTest.py
@@ -1,0 +1,119 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import pika
+from amqp_setup import *
+
+class TestRabbitMQSetup(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ['CHARITY_ENDPOINT'] = "https://mock.charity.api"
+
+    def setUp(self):
+        self.mock_connection = MagicMock(spec=pika.BlockingConnection)
+        self.mock_channel = MagicMock()
+        self.mock_connection.channel.return_value = self.mock_channel
+
+    def test_create_connection_success(self):
+        """Test successful RabbitMQ connection"""
+        with patch('pika.BlockingConnection') as mock_connection:
+            mock_connection.return_value = self.mock_connection
+            connection = create_connection("charitymq", 5672)
+            self.assertIsInstance(connection, MagicMock)
+            mock_connection.assert_called_once_with(
+                pika.ConnectionParameters(
+                    host="charitymq",
+                    port=5672,
+                    heartbeat=300,
+                    blocked_connection_timeout=300
+                )
+            )
+
+    def test_create_connection_failure(self):
+        """Test connection failure handling"""
+        with patch('pika.BlockingConnection', side_effect=Exception("Connection failed")):
+            with self.assertRaises(Exception):
+                create_connection("invalid_host", 5672)
+
+    def test_create_exchange(self):
+        """Test exchange creation with correct parameters"""
+        with patch('pika.BlockingConnection') as mock_connection:
+            mock_connection.return_value = self.mock_connection
+            connection = create_connection("charitymq", 5672)
+            channel = create_exchange(connection, "test_exchange", "direct")
+            
+            self.mock_channel.exchange_declare.assert_called_once_with(
+                exchange="test_exchange",
+                exchange_type="direct",
+                durable=True
+            )
+
+    def test_create_queue(self):
+        """Test queue creation and binding"""
+        test_params = {
+            "exchange_name": "test_exchange",
+            "queue_name": "test_queue",
+            "routing_key": "test.key"
+        }
+        
+        create_queue(self.mock_channel, **test_params)
+        
+        self.mock_channel.queue_declare.assert_called_once_with(
+            queue="test_queue",
+            durable=True
+        )
+        self.mock_channel.queue_bind.assert_called_once_with(
+            exchange="test_exchange",
+            queue="test_queue",
+            routing_key="test.key"
+        )
+
+    @patch('requests.get')
+    def test_setup_success(self, mock_get):
+        """Test full setup process with mock API response"""
+        # Mock API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {"ID": 1, "CharityName": "Charity1"},
+            {"ID": 2, "CharityName": "Charity2"}
+        ]
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        # Mock RabbitMQ connection
+        with patch('pika.BlockingConnection') as mock_connection, \
+             patch('amqp_setup.create_exchange') as mock_create_exchange:
+            
+            mock_connection.return_value = self.mock_connection
+            mock_create_exchange.return_value = self.mock_channel
+            
+            setup()
+            
+            # Verify API call
+            mock_get.assert_called_once_with(
+                "https://personal-d4txim0d.outsystemscloud.com/Charity/rest/CharityAPI/GetAllCharityIDName"
+            )
+            
+            # Verify queue creation for each charity
+            expected_calls = [
+                unittest.mock.call(
+                    exchange_name=exchange_name,
+                    queue_name="Charity1",
+                    routing_key="charity.1"
+                ),
+                unittest.mock.call(
+                    exchange_name=exchange_name,
+                    queue_name="Charity2",
+                    routing_key="charity.2"
+                )
+            ]
+            self.mock_channel.queue_declare.assert_any_call(
+                queue="Charity1", durable=True
+            )
+            self.mock_channel.queue_bind.assert_any_call(
+                exchange=exchange_name,
+                queue="Charity1",
+                routing_key="charity.1"
+            )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/rabbitMQ/rabbitMQ_SetUpTest.py
+++ b/backend/rabbitMQ/rabbitMQ_SetUpTest.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import pika
+import os
 from amqp_setup import *
 
 class TestRabbitMQSetup(unittest.TestCase):
@@ -86,22 +87,25 @@ class TestRabbitMQSetup(unittest.TestCase):
             mock_connection.return_value = self.mock_connection
             mock_create_exchange.return_value = self.mock_channel
             
-            setup()
-            
-            # Verify API call
-            mock_get.assert_called_once_with(
-                "https://personal-d4txim0d.outsystemscloud.com/Charity/rest/CharityAPI/GetAllCharityIDName"
-            )
-            
+            test_params = {
+            "amqp_host": "localhost",
+            "amqp_port": 5672,
+            "exchange_name": "charity_exchange",
+            "exchange_type": "direct",
+            "CHARITY_ENDPOINT": "https://personal-d4txim0d.outsystemscloud.com/Charity/rest/CharityAPI",
+            }
+
+            setup(**test_params)
+
             # Verify queue creation for each charity
             expected_calls = [
                 unittest.mock.call(
-                    exchange_name=exchange_name,
+                    exchange_name="charity_exchange",
                     queue_name="Charity1",
                     routing_key="charity.1"
                 ),
                 unittest.mock.call(
-                    exchange_name=exchange_name,
+                    exchange_name="charity_exchange",
                     queue_name="Charity2",
                     routing_key="charity.2"
                 )
@@ -110,7 +114,7 @@ class TestRabbitMQSetup(unittest.TestCase):
                 queue="Charity1", durable=True
             )
             self.mock_channel.queue_bind.assert_any_call(
-                exchange=exchange_name,
+                exchange="charity_exchange",
                 queue="Charity1",
                 routing_key="charity.1"
             )

--- a/backend/rabbitMQ/requirements.txt
+++ b/backend/rabbitMQ/requirements.txt
@@ -1,0 +1,3 @@
+pika>=1.3.1
+requests>=2.31.0
+python-dotenv==1.0.1

--- a/backend/rabbitMQ/startAMQP.py
+++ b/backend/rabbitMQ/startAMQP.py
@@ -1,4 +1,14 @@
 from amqp_setup import setup
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+amqp_host = "charitymq"
+amqp_port = 5672
+exchange_name = "charity_exchange"
+exchange_type = "direct"
+CHARITY_ENDPOINT: str = os.getenv('CHARITY_ENDPOINT', "https://personal-d4txim0d.outsystemscloud.com/Charity/rest/CharityAPI")
 
 if __name__ == '__main__':
-    setup()
+    setup(amqp_host,amqp_port,exchange_name,exchange_type,CHARITY_ENDPOINT)

--- a/backend/rabbitMQ/startAMQP.py
+++ b/backend/rabbitMQ/startAMQP.py
@@ -1,0 +1,4 @@
+from amqp_setup import setup
+
+if __name__ == '__main__':
+    setup()

--- a/cloudpantry/src/common/pathVariables.js
+++ b/cloudpantry/src/common/pathVariables.js
@@ -8,3 +8,6 @@ export const INVENTORY_URL = `http://localhost:${INVENTORY_PORT}/inventory`;
 export const EXCESS_INVENTORY_URL = `http://localhost:${EXCESS_INVENTORY_PORT}/inventory`;
 export const NOTIFICATION_URL = `http://localhost:${NOTIFICATION_PORT}/notification`;
 export const ONEMAP_URL = `http://localhost:${ONEMAP_PORT}/notification`;
+
+export const CHARITY_ENDPOINT = "https://personal-d4txim0d.outsystemscloud.com/Charity/rest/CharityAPI"
+export const RECIPIENT_ENDPOINT = "https://personal-d4txim0d.outsystemscloud.com/Recipient/rest/RecipientAPI"


### PR DESCRIPTION
Refactored message microservice code. RabbitMQ now does the following tasks

1. Starts up RabbitMQ on initialization
2. Sets up exchange
3. Sets up queue for all existing charities

This refactoring changes the set up of RabbitMQ. RabbitMQ will now be a persistent service and focus on set up and passing on messages. Message service will be refactored to focus on solely publishing and subscribing. Additionally, instead of a single message service in control of a single exchange and all queues, one message service will be initiated for each charity upon login, and will then subscribe to an existing created queue.

Function within amqp_setup.py can be reused to set up new queues for new registration.